### PR TITLE
Updating preact version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "d3-hierarchy": "^1.0.3",
     "d3-interpolate": "^1.1.3",
-    "preact": "^7.2.0"
+    "preact": "^8.2.5"
   },
   "devDependencies": {
     "@types/d3-hierarchy": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,9 +1972,9 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-preact@^7.2.0:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-7.2.1.tgz#159e1892f614985e49eb0a96fd6e6d8bdf8bbcc5"
+preact@^8.2.5:
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.5.tgz#cbfa3962a8012768159f6d01d46f9c1eb3213c0a"
 
 prepend-http@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
This is literally the first PR I've opened to an open source project so if this isn't quite what I should be doing feel free to close this.

In any case, using the visualizer in my project and this looks to be the only package that complains about TypeScript 2.4.x, so I thought I'd see if I could update it myself. I ran the sample included in the package.json and I believe it's fine.

Let me know how that works I suppose.