### PR TITLE
fix(css): Add 'nonce' attribute to style-loader to prevent CSP violations due to inline styles

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,7 @@ module.exports = {
     loaders: [
       { test: /\.tsx?$/, loader: 'ts-loader', options: { transpileOnly: true } },
       { test: /\.css$/, loader: [
-        { loader: 'style-loader', options: { hmr: false } },
+        { loader: 'style-loader', options: { hmr: false, attrs: { nonce: "uiroutervisualizer" } } },
         { loader: 'css-loader?sourceMap-loader' },
       ] },
       // inline base64 URLs for <=8k images, direct URLs for the rest


### PR DESCRIPTION
Fixes #12 

The 'nonce' is only relevant in case the visualizer is used in a CSP compliant app so that the nonce can be added to the CSP directives of the app in order to mark that content as trusted and thus not to be blocked.