### PR TITLE
chore(package): pin preact to version 8.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "d3-hierarchy": "^1.1.6",
     "d3-interpolate": "^1.2.0",
     "file-loader": "^1.1.11",
-    "preact": "^8.2.9"
+    "preact": "~8.3.1"
   },
   "devDependencies": {
     "@types/d3-hierarchy": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4021,9 +4021,9 @@ postcss@^6.0.23:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-preact@^8.2.9:
-  version "8.2.9"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
+preact@~8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.3.1.tgz#ed34f79d09edc5efd32a378a3416ef5dc531e3ac"
 
 preserve@^0.2.0:
   version "0.2.0"
@@ -5274,8 +5274,8 @@ unset-value@^1.0.0:
     isobject "^3.0.0"
 
 upath@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
 uri-js@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
preact 8.4.0 uses TypeScript 3.0 to build declarations, see https://github.com/developit/preact/commit/8f9b8298a581af6bba10a15f8bf1d9d795763c1d
However it introduces breaking change for testing `visualizer` against `sticky-states` (note that we have no lockfiles [here](https://github.com/ui-router/sticky-states/tree/master/examples/angular-cli)), now preact is pin to 8.3.1 before typescript devDependencies is upgraded to 3

The issue is blocking https://github.com/ui-router/core/pull/286 and the [build failure](https://travis-ci.org/ui-router/core/builds/461309093?utm_source=github_status&utm_medium=notification) shall be resolved once this PR is merged and a new version of `@ui-router/visualizer` is published.

@christopherthielen Hope you can find some time to review, thanks.